### PR TITLE
changing resolve interface

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -33,36 +33,36 @@ function moduleFindOrCreate(schema) {
 
       // Find document
       this.findOne(query)
-        .then(result => {
+        .then(doc => {
           // If document exist
-          if (result) {
+          if (doc) {
             if (options && options.upsert) {
               /**
                * Update document
                * Find the new document
                * Return new document
                */
-              _id = result._id;
+              _id = doc._id;
               return Collection.update(query, data);
             }
             // Return document
-            resolve({ result, created: false });
-            return null;
+            resolve(([doc, false]);
+            return;
           } else if (options && !options.create) {
             // If create is false, return null
-            resolve({ result: null, created: false });
+            resolve(([null, false]);
           } else {
             // Create document
             resolve(
               Collection.create(data ? Object.assign({}, query, data) : query)
-              .then(doc => ({ result: doc, created: true }))
-              .catch(err => (err))
+              .then(doc => [doc, true])
+              .catch(err => throw err)
             );
           }
           return null;
         })
         .then(() => Collection.findOne({ _id }))
-        .then(result => resolve({ result, created: false }))
+        .then(doc => resolve([doc, false]))
         .catch(reject);
     });
   };


### PR DESCRIPTION
Just a proposal but would be way nicer to be able to do a 
let [ user, isCreated ] = await Users.findOrCreate({username: "admin"}, {password:"qwerty"});
instead of 
let {result: user, created: isCreated} = await User.findOrCreate({username: "admin"}, {password:"qwerty"});